### PR TITLE
Update documentation with split NOTICE.md files per repo

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -45,47 +45,11 @@ jobs:
           # cloned repositories as the current branch name
           branch_name=${{ github.ref_name }}
 
-          #
-          # Clone public rspy repositories
-
-          git clone https://github.com/RS-PYTHON/rs-server.git
-          (cd rs-server; git checkout $branch_name || git checkout develop)
-
-          git clone https://github.com/RS-PYTHON/rs-client-libraries.git
-          (cd rs-client-libraries; git checkout $branch_name || git checkout develop)
-
-          git clone https://github.com/RS-PYTHON/rs-demo.git
-          (cd rs-demo; git checkout $branch_name || git checkout develop)
-
-          git clone https://github.com/RS-PYTHON/rs-dpr-service.git
-          (cd rs-dpr-service; git checkout $branch_name || git checkout develop)
-
-          ls -all
-
-          # Clone private rspy repositories.
-          # Use the ssh private key from: https://github.com/RS-PYTHON/rs-documentation/settings/secrets/actions
-          # And the public keys from:
-            #   https://github.com/RS-PYTHON/rs-infra-core/settings/keys
-            #   https://github.com/RS-PYTHON/rs-helm/settings/keys
-
-          eval "$(ssh-agent -s)"
-          ssh-add - <<< "${{ secrets.RS_INFRA_PRIVATE_SSH_KEY }}"
-          git clone --depth 1 git@github.com:RS-PYTHON/rs-infra-core.git
-          cd rs-infra-core
-          git checkout $branch_name || git checkout develop
-          git sparse-checkout init --no-cone
-          echo "/docs/" > .git/info/sparse-checkout
-          echo "/LICENSE" >> .git/info/sparse-checkout
-          echo "/NOTICE.md" >> .git/info/sparse-checkout
-          echo "/README.md" >> .git/info/sparse-checkout
-          git read-tree -mu HEAD
-          ls -all
-          cd ..
-
-          eval "$(ssh-agent -s)"
-          ssh-add - <<< "${{ secrets.RS_HELM_PRIVATE_SSH_KEY }}"
-          git clone git@github.com:RS-PYTHON/rs-helm.git
-          (cd rs-helm; git checkout $branch_name || git checkout develop)
+          # Clone rspy repositories
+          for repo in rs-server rs-client-libraries rs-demo rs-dpr-service rs-infra-core rs-infra-monitoring rs-workflow-env rs-helm ; do
+            git clone https://github.com/RS-PYTHON/${repo}.git
+            (cd ${repo}; git checkout $branch_name || git checkout develop)
+          done
         working-directory: .
         shell: bash
 

--- a/mkdocs.yml.tpl
+++ b/mkdocs.yml.tpl
@@ -1,7 +1,7 @@
 site_name: RS-Python
 #site_url: https://rs-python.github.io/rs-documentation/
 # Copyright
-copyright: Copyright &copy; 2024-2026, ESA
+copyright: Copyright &copy; 2024-2026, Airbus, CS Group
 
 theme:
   name: material
@@ -49,8 +49,8 @@ plugins:
       handlers:
         python:
           options:
-            extra:              
-              separate_modules: true              
+            extra:
+              separate_modules: true
 
 nav:
 - Home:
@@ -110,4 +110,8 @@ $RS_DPR_SERVICE_PYDOCS
   - Applications Deployment:
     - RS-Server deployment: rs-helm/README.md
   - Monitor Object Storage access:
-    - Deploy flow collect-obs-logs : rs-client-libraries/docs/quota_monitoring/setting_quota_feature.md
+    - Deploy flow collect-obs-logs: rs-client-libraries/docs/quota_monitoring/setting_quota_feature.md
+  - Third-party dependencies:
+    - Core infrastructure FOSS: rs-infra-core/NOTICE.md
+    - Monitoring FOSS: rs-infra-monitoring/NOTICE.md
+    - Workflow env. FOSS: rs-workflow-env/NOTICE.md


### PR DESCRIPTION
List the different infrastructure NOTICE.md files in the published documentation.

Simplify the checkout of repositories now they are all public.